### PR TITLE
rename 'Primitive' class to 'Provider'

### DIFF
--- a/sample_user_plugins/ssn.py
+++ b/sample_user_plugins/ssn.py
@@ -1,10 +1,10 @@
 from faker import Faker
 
 import data_generator.factory as factory
-from data_generator.core import Primitive
+from data_generator.core import Provider
 
 
-class SSN(Primitive):
+class SSN(Provider):
     @classmethod
     def get_provider_name(cls):
         return "com.github.kbaafi.us_ssn"

--- a/src/data_generator/core/__init__.py
+++ b/src/data_generator/core/__init__.py
@@ -1,3 +1,3 @@
-from .core import Component, Composite, Plural, Primitive
+from .core import Component, Composite, Plural, Provider
 
-__all__ = ["Component", "Composite", "Primitive", "Plural"]
+__all__ = ["Component", "Composite", "Provider", "Plural"]

--- a/src/data_generator/core/core.py
+++ b/src/data_generator/core/core.py
@@ -76,7 +76,7 @@ class Plural(Component):
         return composite
 
 
-class Primitive(Component):
+class Provider(Component):
     def __init__(self, **kwargs):
         self._field_name = None
         self._kwargs = kwargs
@@ -99,5 +99,5 @@ class Primitive(Component):
 
     def generate_data(self):
         raise NotImplementedError(
-            "Data generation of a primitive must be implemented in subclass"
+            "Data generation of a provider must be implemented in subclass"
         )

--- a/src/data_generator/factory.py
+++ b/src/data_generator/factory.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict
 
-from .core import Primitive
+from .core import Provider
 from .plugins_loader import load_plugins
 from .providers import FirstName, LastName, RandomInt, Text
 
-providers: Dict[str, Primitive] = {}
+providers: Dict[str, Provider] = {}
 
 
-def register_provider(provider_name: str, provider: Primitive):
+def register_provider(provider_name: str, provider: Provider):
     if provider_name in providers:
         raise ValueError(
             f"Specified provider already exists. Provider Name: {provider_name}"
@@ -15,7 +15,7 @@ def register_provider(provider_name: str, provider: Primitive):
     providers.update({provider_name: provider})
 
 
-def get_provider(provider_name: str, provider_kwargs: Dict[str, Any] = {}) -> Primitive:
+def get_provider(provider_name: str, provider_kwargs: Dict[str, Any] = {}) -> Provider:
     if provider_name in providers:
         provider = providers[provider_name]
         provider.provider_kwargs = provider_kwargs
@@ -23,7 +23,7 @@ def get_provider(provider_name: str, provider_kwargs: Dict[str, Any] = {}) -> Pr
     raise ValueError(f"Specified provider {provider_name} is not supported")
 
 
-def build_primitives_factory(plugins_dir: str = None):
+def create_provider_factory(plugins_dir: str = None):
     register_provider(FirstName.get_provider_name(), FirstName())
     register_provider(LastName.get_provider_name(), LastName())
     register_provider(RandomInt.get_provider_name(), RandomInt())

--- a/src/data_generator/providers/random_int.py
+++ b/src/data_generator/providers/random_int.py
@@ -1,6 +1,6 @@
 from faker import Faker
 
-from ..core import Primitive
+from ..core import Provider
 
 faker = Faker()
 
@@ -11,7 +11,7 @@ DEFAULT_MIN_VALUE = 0
 DEFAULT_MAX_VALUE = 999999
 
 
-class RandomInt(Primitive):
+class RandomInt(Provider):
     @property
     def field_name(self):
         return self._field_name

--- a/src/data_generator/providers/simple_text.py
+++ b/src/data_generator/providers/simple_text.py
@@ -1,6 +1,6 @@
 from faker import Faker
 
-from ..core import Primitive
+from ..core import Provider
 
 DEFAULT_TEXT_MAX_NB_CHARS = 20
 
@@ -15,7 +15,7 @@ def str_to_int(int_str: str) -> int:
         return 0
 
 
-class Text(Primitive):
+class Text(Provider):
     @classmethod
     def get_provider_name(cls) -> str:
         return "text"
@@ -34,7 +34,7 @@ class Text(Primitive):
         return faker.text(max_nb_chars=self._max_nb_chars)
 
 
-class FirstName(Primitive):
+class FirstName(Provider):
     @classmethod
     def get_provider_name(cls) -> str:
         return "first_name"
@@ -43,7 +43,7 @@ class FirstName(Primitive):
         return faker.first_name()
 
 
-class LastName(Primitive):
+class LastName(Provider):
     @classmethod
     def get_provider_name(cls) -> str:
         return "last_name"

--- a/src/data_generator/synth.py
+++ b/src/data_generator/synth.py
@@ -23,7 +23,7 @@ def convert_max_str_int(max_str: str) -> int:
 
 def generate_data(schema: Dict[str, Any], plugins_dir: str = None) -> Dict[str, Any]:
     # Load providers
-    factory.build_primitives_factory(plugins_dir)
+    factory.create_provider_factory(plugins_dir)
 
     data_object_model = generate_dom(DOM_ROOT_KEY, schema=schema)
     data = data_object_model.generate_data()


### PR DESCRIPTION
Even though Providers create Primitives, it is important for the sake of clarity to maintain a common vocabulary within the application to change the name of the base class to 'Provider'.